### PR TITLE
Fixed Windows max conflict

### DIFF
--- a/include/particulate/Rle.hpp
+++ b/include/particulate/Rle.hpp
@@ -59,7 +59,7 @@ namespace particulate { namespace rle {
 		mFh( f ),
 		mLen( 0 ),
 		mCount( 0 ),
-		mValue( (std::numeric_limits<size_t>::max())() )
+		mValue( (std::numeric_limits<size_t>::max)() )
 		{
 			mFh.seekp( 0, std::ios::beg );
 			write_to_stream( mFh, mLen );

--- a/include/particulate/Rle.hpp
+++ b/include/particulate/Rle.hpp
@@ -59,7 +59,7 @@ namespace particulate { namespace rle {
 		mFh( f ),
 		mLen( 0 ),
 		mCount( 0 ),
-		mValue( std::numeric_limits<size_t>::max() )
+		mValue( (std::numeric_limits<size_t>::max())() )
 		{
 			mFh.seekp( 0, std::ios::beg );
 			write_to_stream( mFh, mLen );

--- a/include/particulate/Rle.hpp
+++ b/include/particulate/Rle.hpp
@@ -30,6 +30,12 @@
 #include <vector>
 #include <string>
 
+#ifndef assert
+#ifdef _WIN32
+#define assert(x) _ASSERT(x)
+#endif
+#endif
+
 namespace particulate { namespace rle {
 	
 	template <typename Tp>


### PR DESCRIPTION
Issue described here:

http://stackoverflow.com/questions/1904635/warning-c4003-and-errors-c2589-and-c2059-on-x-stdnumeric-limitsintmax

In short, Windows has a `max` define that confuses the compiler. 
